### PR TITLE
사이드바 추가

### DIFF
--- a/src/pages/SideBar.jsx
+++ b/src/pages/SideBar.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import styled from 'styled-components';
+
+function SideBar({ onClose }) {
+  return (
+    <Wrapper onClick={onClose}>
+      <SidebarContent onClick={(e) => e.stopPropagation()}>SideBar</SidebarContent>
+    </Wrapper>
+  );
+}
+
+export default SideBar;
+
+const Wrapper = styled.div`
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  z-index: 30;
+`;
+
+const SidebarContent = styled.div`
+  width: 30rem;
+  height: 100%;
+  background-color: #000000;
+  transform: translateX(0);
+  transition: transform 0.3s;
+`;

--- a/src/shared/Layout.jsx
+++ b/src/shared/Layout.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Outlet, Link } from 'react-router-dom';
 import styled from 'styled-components';
 
@@ -6,8 +6,14 @@ import styled from 'styled-components';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faBars } from '@fortawesome/free-solid-svg-icons';
 import { faMagnifyingGlass } from '@fortawesome/free-solid-svg-icons';
+import SideBar from '../pages/SideBar';
 
 function Layout() {
+  const [sidebarVisible, setSidebarVisible] = useState(false);
+
+  const toggleSidebar = () => {
+    setSidebarVisible(!sidebarVisible);
+  };
   return (
     <>
       <Header>
@@ -23,9 +29,10 @@ function Layout() {
         <HeaderRight>
           <Link to="/">로그인</Link>
           <Link to="/">회원가입</Link>
-          <FontAwesomeIcon icon={faBars} />
+          <FontAwesomeIcon style={{ fontSize: '24px' }} icon={faBars} onClick={toggleSidebar} />
         </HeaderRight>
       </Header>
+      {sidebarVisible && <SideBar onClose={toggleSidebar} />}
       <Outlet />
       <footer></footer>
     </>


### PR DESCRIPTION
헤더의 버튼을 클릭했을때 사이드바가 나오는 것을 추가했습니다.
```
`  const [sidebarVisible, setSidebarVisible] = useState(false);`
  const toggleSidebar = () => {
    setSidebarVisible(!sidebarVisible);
  };
```
사이드바를 useState를 사용하여 추가하였습니다.
`<FontAwesomeIcon style={{ fontSize: '24px' }} icon={faBars} onClick={toggleSidebar} />`
props를 이용해 넘겨주고 사이드바에서 받아줍니다.
